### PR TITLE
Make faraday web requests timeout before before DelayedJob max_run_time

### DIFF
--- a/app/concerns/web_request_concern.rb
+++ b/app/concerns/web_request_concern.rb
@@ -125,6 +125,8 @@ module WebRequestConcern
         builder.options.params_encoder = DoNotEncoder
       end
 
+      builder.options.timeout = (Delayed::Worker.max_run_time.seconds - 2).to_i
+
       if userinfo = basic_auth_credentials
         builder.request :basic_auth, *userinfo
       end


### PR DESCRIPTION
DelayedJob uses `Timeout` to ensure the job runtime which is not thread
safe.

Faraday's `timeout` option works well for our default `typhoeus`
adapter. When using `net-http` it only works for none
"IDEMPOTENT_METHODS" since those are retried once per default [1].

[1] https://github.com/ruby/ruby/blob/86bfcc2da07d524845fbfb3a458a84cc8bd3ecf1/lib/net/http.rb#L1464

 #1888
 #1567